### PR TITLE
Clean up error messages

### DIFF
--- a/src/errors/PlatformAgnostic.ts
+++ b/src/errors/PlatformAgnostic.ts
@@ -14,3 +14,15 @@ export const unhandledException = (
     'Retry with an exponential backoff. Consider filing an issue with the `expo-app-integrity` repository.',
   resolutionType: ErrorResolutionTypes.DEVELOPER_ACTION_REQUIRED,
 })
+
+export const PlatformAgnosticErrors = {
+  UNSUPPORTED_PLATFORM: {
+    code: 'UNSUPPORTED_PLATFORM',
+    errorCode: 27,
+    documentation: 'https://gihub.com/jeffDevelops/expo-app-integrity',
+    detail: `The current platform is not supported by this library. Only 'ios' and 'android' are supported.`,
+    userFriendlyMessage: 'App integrity verification failed.',
+    resolution: 'Use this library only on iOS and Android.',
+    resolutionType: ErrorResolutionTypes.DEVELOPER_ACTION_REQUIRED,
+  },
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import {
   iOSAppAttestErrors,
   AndroidIntegrityErrors,
   unhandledException,
+  PlatformAgnosticErrors,
 } from './errors'
 
 /** iOS Only */
@@ -168,15 +169,11 @@ export async function attestKey(
       return await iOSAttestKey(challenge)
     case 'android':
       if (!cloudProjectNumber)
-        throw new Error(
-          'cloudProjectNumber is required for attestation with Google Play Integrity API',
-        )
+        throw AndroidIntegrityErrors.CLOUD_PROJECT_NUMBER_IS_INVALID
 
       return await androidRequestIntegrityVerdict(challenge, cloudProjectNumber)
     default:
-      throw new Error(
-        'Unsupported platform. Supported platforms are iOS and Android.',
-      )
+      throw PlatformAgnosticErrors.UNSUPPORTED_PLATFORM
   }
 }
 


### PR DESCRIPTION
Previously, unsupported platform and missing Android project number errors were thrown as strings, rather than instances of the AppIntegrityError type.