### PR TITLE
Fix Build fails with expo-app-integrity on Gradle 8 issue #6

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 
@@ -35,19 +35,11 @@ buildscript {
   }
 }
 
-// Creating sources with comments
-task androidSourcesJar(type: Jar) {
-  classifier = 'sources'
-  from android.sourceSets.main.java.srcDirs
-}
-
 afterEvaluate {
   publishing {
     publications {
       release(MavenPublication) {
         from components.release
-        // Add additional sourcesJar to artifacts
-        artifact(androidSourcesJar)
       }
     }
     repositories {
@@ -59,7 +51,8 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  expo.modules.integrity = "expo.modules.integrity"
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,12 +65,17 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 1
     versionName "0.1.0"
   }
   lintOptions {
     abortOnError false
+  }
+  publishing {
+    singleVariant("release") {
+      withSourcesJar()
+    }
   }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -51,7 +51,7 @@ afterEvaluate {
 }
 
 android {
-  expo.modules.integrity = "expo.modules.integrity"
+  namespace = "expo.modules.integrity"
   compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
-<manifest package="expo.modules.integrity">
+<manifest>
 </manifest>

--- a/expo-module.config.json
+++ b/expo-module.config.json
@@ -1,5 +1,5 @@
 {
-  "platforms": ["ios", "android", "web"],
+  "platforms": ["android"],
   "ios": {
     "modules": ["IntegrityModule"]
   },

--- a/expo-module.config.json
+++ b/expo-module.config.json
@@ -1,5 +1,5 @@
 {
-  "platforms": ["android"],
+  "platforms": ["ios", "android", "web"],
   "ios": {
     "modules": ["IntegrityModule"]
   },


### PR DESCRIPTION
#6  update build.gradle and AndroidManifest.xml following the migration guide:
https://github.com/expo/fyi/blob/main/expo-modules-gradle8-migration.md
so it can build with Gradle 8 and the latest versions of expo.